### PR TITLE
Schoolcountfix

### DIFF
--- a/server.R
+++ b/server.R
@@ -864,7 +864,7 @@ server <- function(input, output, session) {
       geographic_level == "National",
       school_type == "Total",
       time_identifier == max(time_identifier),
-      day_number == "4"
+      day_number == "5"
     ) %>%
     pull(num_schools) %>%
     sum()

--- a/tests/shinytest/UI_tests-expected/001.json
+++ b/tests/shinytest/UI_tests-expected/001.json
@@ -14,7 +14,7 @@
     "ts_choice": "Most recent week"
   },
   "output": {
-    "daily_schools_count": "14,359 schools provided information on the most recent full day of data, i.e. 2022-09-16",
+    "daily_schools_count": "14,341 schools provided information on the most recent full day of data, i.e. 2022-09-16",
     "headline_update_date": "Data was last updated on 2022-09-29.",
     "homepage_update_dates": "Data was last updated on 2022-09-29 and is next expected to be updated on 2022-10-13. The most recent full week of data was the week commencing 2022-09-12."
   },


### PR DESCRIPTION
## Pull request overview

Fixing school count figure on dashboard homepage

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

School count figure currently is number of schools reporting on the thursday, not the friday as the date suggests


## What is the new behaviour?

Amended so count figure is being pulled from Friday

