### PR TITLE
Reasons time period toggle

### DIFF
--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -7,7 +7,7 @@ homepage_panel <- function() {
       fluidRow(
         column(
           12,
-          h1("Pupil attendance and absence in schools in England"),
+          h1("Pupil attendance and absence in schools in England"), 
           textOutput("headline_update_date"),
           br(),
         ),
@@ -100,8 +100,8 @@ homepage_panel <- function() {
                   br(),
                   br(),
                   h4("If you are a school that has not yet signed up to share your data, please visit ", 
-                    a(href = "https://www.gov.uk/guidance/share-your-daily-school-attendance-data", "Share your daily school attendance data"), "for more information. This will also give you, your local authority and your multi-academy trust (if applicable)",
-                    a(href = "https://esfahelp.education.gov.uk/hc/en-gb/articles/6176380401810-School-Daily-Attendance-Trial?utm_source=5%20September%202022%20C19&utm_medium=Daily%20Email%20C19&utm_campaign=DfE%20C19", "access to daily attendance reports"), "to help identify pupils needing attendance support earlier."),
+                     a(href = "https://www.gov.uk/guidance/share-your-daily-school-attendance-data", "Share your daily school attendance data"), "for more information. This will also give you, your local authority and your multi-academy trust (if applicable)",
+                     a(href = "https://esfahelp.education.gov.uk/hc/en-gb/articles/6176380401810-School-Daily-Attendance-Trial?utm_source=5%20September%202022%20C19&utm_medium=Daily%20Email%20C19&utm_campaign=DfE%20C19", "access to daily attendance reports"), "to help identify pupils needing attendance support earlier."),
                   br(),
                 ),
               )
@@ -127,254 +127,281 @@ dashboard_panel <- function() {
     # Sidebar with a slider input for number of bins
     
     gov_main_layout(
-    
-    h1("Attendance and absence headlines and reasons"),
-    
-    
-    
-    div(
-      class = "well",
-      style = "min-height: 100%; height: 100%; overflow-y: visible",
-      fluidRow(
-        column(
-          width=6,
-          fluidRow(
-        column(
-          width=6,
-          selectInput(inputId = "school_choice",
-                      label = "Choose school type:",
-                      choices = school_type_lookup %>% dplyr::filter(geographic_level == "National") %>% dplyr::select(school_type) %>% unique() %>% as.data.table(),
-                      selected = "Primary"
-          )
-        ),
-        column(width=6,
-               conditionalPanel(condition = "input.dash == 'headlines'",
-                                selectInput(inputId = "ts_choice",
-                                            label = "Choose time period:",
-                                            choices = c("Most recent week", "Year to date")
-                                )
-                                )
-        )
-        ),
-        fluidRow(
-          column(
-            width=6,
-            p(strong("Download underlying data")),
-            downloadButton("downloadData2", label = "Download data", style = "width:100%;white-space:normal;")
-          ),
-          column(
-            width=6,
-            p(strong("For more tables and metadata")),
-            actionButton(inputId='ees', 
-                         label="Visit Explore Education Statistics", 
-                         icon = icon("th"), 
-                         onclick ="window.open('https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools', '_blank')",
-                         style = "width:100%;white-space:normal;")
-            
-          )
-        )
-      ),
-        column(
-          width=3,
-          conditionalPanel(condition = "input.dash == 'headlines'|| input.dash == 'reasons'",
-                           selectInput(inputId = "geography_choice",
-                                       label = "Choose geographic level:",
-                                       choices = c("National","Regional","Local authority"),
-                                       selected = head(geog_levels,1)))
-        ),
-        column(
-          width=3,
-          conditionalPanel(condition = "input.geography_choice == 'Regional' && input.dash != 'la comparisons' || input.geography_choice == 'Local authority' && input.dash != 'la comparisons'", 
-                           selectInput(inputId = "region_choice",
-                                       label = "Choose region:",
-                                       choices = geog_lookup %>% dplyr::filter(geographic_level == 'National') %>% dplyr::select(region_name) %>% unique() %>% as.data.table(),
-                                       #selected = head(reg_geog,1)
-                           )),
-          conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.dash != 'la comparisons'", 
-                           selectInput(inputId = "la_choice",
-                                       label = "Choose local authority:",
-                                       choices = geog_lookup %>% dplyr::filter(region_name == "East Midlands") %>% dplyr::select(la_name) %>% unique() %>% as.data.table(),
-                                       #selected = la_geog()[2,1]
-                           ))
-        )
-      )
       
-
-    ),
-    tabsetPanel(
-      id = 'dash',
-      tabPanel(
-        value = "headlines",
-        title = "Headlines",
-        fluidPage(
-          fluidRow(
-            br(),
-            conditionalPanel(condition = "input.geography_choice == 'National'", 
-                             h4(textOutput("headline_bullet_title_nat"
-                             ))),
-            conditionalPanel(condition = "input.geography_choice == 'Regional'", 
-                             h4(textOutput("headline_bullet_title_reg"
-                             ))),
-            conditionalPanel(condition = "input.geography_choice == 'Local authority'", 
-                             h4(textOutput("headline_bullet_title_la"
-                             ))),
-            conditionalPanel(condition = "input.ts_choice == 'Most recent week'",
-                             textOutput("school_count_proportion_weekly"),
-                             textOutput("update_dates"),
-                             p("Data for earlier weeks has not been included in the dashboard due to the impact of different start dates, inset days and phased returns. National level data covering the week commencing 5th September is available on", a(href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools", "Explore Education Statistics")),
-            ),
-            conditionalPanel(condition = "input.ts_choice == 'Year to date'",
-                             textOutput("school_count_proportion_weekly2"),
-                             textOutput("update_dates2"),
-                             p("Data for earlier weeks has not been included in the dashboard due to the impact of different start dates, inset days and phased returns. National level data covering the week commencing 5th September is available on", a(href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools", "Explore Education Statistics")),
-            ),
-            
-            br(),
-            conditionalPanel(condition = "input.ts_choice == 'Year to date'",
-                             p(strong(paste0("Attendance and absence across year to date")))),
-            conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_attendance_rate_nat"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_attendance_rate_reg"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_attendance_rate_la"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_absence_rate_nat"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_absence_rate_reg"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_absence_rate_la"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_illness_rate_nat"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_illness_rate_reg"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Year to date'", 
-                             textOutput("ytd_illness_rate_la"
-                             )),
-            conditionalPanel(condition = "input.ts_choice == 'Most recent week'",
-                             p(strong(paste0("Attendance and absence in the most recent week")))),
-            conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_attendance_rate_nat"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_attendance_rate_reg"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_attendance_rate_la"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_absence_rate_nat"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_absence_rate_reg"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_absence_rate_la"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_illness_rate_nat"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_illness_rate_reg"
-                             )),
-            conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Most recent week'", 
-                             textOutput("weekly_illness_rate_la"
-                             )),
-            br(),
-            h5(textOutput("headline_ts_chart_title")),
-            conditionalPanel(condition = "input.ts_choice == 'Year to date'", 
-                             plotlyOutput("absence_rates_timeseries_plot")),
-            conditionalPanel(condition = "input.ts_choice == 'Most recent week'", 
-                             plotlyOutput("absence_rates_daily_plot")),
-            
-          ),
-        )
-      ),
-      tabPanel(
-        value = "reasons",
-        title = "Reasons",
+      h1("Attendance and absence headlines and reasons"),
+      
+      
+      
+      div(
+        class = "well",
+        style = "min-height: 100%; height: 100%; overflow-y: visible",
         fluidRow(
-          br(),
-          br(),
-          conditionalPanel(condition = "input.geography_choice == 'National'", 
-                           h4(textOutput("reasons_chart_title_nat"
-                           ))),
-          conditionalPanel(condition = "input.geography_choice == 'Regional'", 
-                           h4(textOutput("reasons_chart_title_reg"
-                           ))),
-          conditionalPanel(condition = "input.geography_choice == 'Local authority'", 
-                           h4(textOutput("reasons_chart_title_la"
-                           )))
-        ),
-        fluidRow(
-          column(6,
-                 br(),
-                 plotlyOutput("absence_reasons_daily_plot")),
-          column(6,
-                 fluidRow(
-                   
-                   br(),
-                   p(strong(paste0("Authorised absence rate:"))),
-                   shinydashboard::valueBoxOutput("headline_auth_rate_weekly", width = 6),
-                   shinydashboard::valueBoxOutput("headline_auth_rate_ytd", width = 6)
-                 ),
-                 fluidRow(
-                   br(),
-                   p(strong(paste0("Unauthorised absence rate:"))),
-                   shinydashboard::valueBoxOutput("headline_unauth_rate_weekly", width = 6),
-                   shinydashboard::valueBoxOutput("headline_unauth_rate_ytd", width = 6)
-                 )
-          )
-        ),
-        br(),
-        p(strong("Reasons for absence in the most recent week")),
-        p("Authorised absence"),
-        DTOutput("absence_auth_reasons_table"),
-        br(),
-        br(),
-        p("Unauthorised absence"),
-        DTOutput("absence_unauth_reasons_table")
-      ),
-      tabPanel(
-        value = "la comparisons",
-        title = "Local Authority Data",
-        fluidPage(
-          fluidRow(
-            br(),
-            h4(textOutput("map_title")),
-            textOutput("la_clarity_dates"),
+          column(
+            width=6,
             fluidRow(
               column(
-                3,
-                br(),
-                p(strong("Select absence rate of interest from drop down menu to view on the map:")),
-              ),
-              column(
-                3,
-                selectInput(inputId = "measure_choice",
-                            label = "Choose measure of interest:",
-                            choices = c("Overall", "Authorised","Unauthorised")
+                width=6,
+                selectInput(inputId = "school_choice",
+                            label = "Choose school type:",
+                            choices = school_type_lookup %>% dplyr::filter(geographic_level == "National") %>% dplyr::select(school_type) %>% unique() %>% as.data.table(),
+                            selected = "Primary"
                 )
               ),
+              column(width=6,
+                     conditionalPanel(condition = "input.dash == 'headlines'|| input.dash == 'reasons'",
+                                      selectInput(inputId = "ts_choice",
+                                                  label = "Choose time period:",
+                                                  choices = c("Most recent week", "Year to date")
+                                      )
+                     )
+              )
             ),
-            leafletOutput("rates_map"),
+            fluidRow(
+              column(
+                width=6,
+                p(strong("Download underlying data")),
+                downloadButton("downloadData2", label = "Download data", style = "width:100%;white-space:normal;")
+              ),
+              column(
+                width=6,
+                p(strong("For more tables and metadata")),
+                actionButton(inputId='ees', 
+                             label="Visit Explore Education Statistics", 
+                             icon = icon("th"), 
+                             onclick ="window.open('https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools', '_blank')",
+                             style = "width:100%;white-space:normal;")
+                
+              )
+            )
+          ),
+          column(
+            width=3,
+            conditionalPanel(condition = "input.dash == 'headlines'|| input.dash == 'reasons'",
+                             selectInput(inputId = "geography_choice",
+                                         label = "Choose geographic level:",
+                                         choices = c("National","Regional","Local authority"),
+                                         selected = head(geog_levels,1)))
+          ),
+          column(
+            width=3,
+            conditionalPanel(condition = "input.geography_choice == 'Regional' && input.dash != 'la comparisons' || input.geography_choice == 'Local authority' && input.dash != 'la comparisons'", 
+                             selectInput(inputId = "region_choice",
+                                         label = "Choose region:",
+                                         choices = geog_lookup %>% dplyr::filter(geographic_level == 'National') %>% dplyr::select(region_name) %>% unique() %>% as.data.table(),
+                                         #selected = head(reg_geog,1)
+                             )),
+            conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.dash != 'la comparisons'", 
+                             selectInput(inputId = "la_choice",
+                                         label = "Choose local authority:",
+                                         choices = geog_lookup %>% dplyr::filter(region_name == "East Midlands") %>% dplyr::select(la_name) %>% unique() %>% as.data.table(),
+                                         #selected = la_geog()[2,1]
+                             ))
+          )
+        )
+        
+        
+      ),
+      tabsetPanel(
+        id = 'dash',
+        tabPanel(
+          value = "headlines",
+          title = "Headlines",
+          fluidPage(
+            fluidRow(
+              br(),
+              conditionalPanel(condition = "input.geography_choice == 'National'", 
+                               h4(textOutput("headline_bullet_title_nat"
+                               ))),
+              conditionalPanel(condition = "input.geography_choice == 'Regional'", 
+                               h4(textOutput("headline_bullet_title_reg"
+                               ))),
+              conditionalPanel(condition = "input.geography_choice == 'Local authority'", 
+                               h4(textOutput("headline_bullet_title_la"
+                               ))),
+              conditionalPanel(condition = "input.ts_choice == 'Most recent week'",
+                               textOutput("school_count_proportion_weekly"),
+                               textOutput("update_dates"),
+                               p("Data for earlier weeks has not been included in the dashboard due to the impact of different start dates, inset days and phased returns. National level data covering the week commencing 5th September is available on", a(href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools", "Explore Education Statistics")),
+              ),
+              conditionalPanel(condition = "input.ts_choice == 'Year to date'",
+                               textOutput("school_count_proportion_weekly2"),
+                               textOutput("update_dates2"),
+                               p("Data for earlier weeks has not been included in the dashboard due to the impact of different start dates, inset days and phased returns. National level data covering the week commencing 5th September is available on", a(href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools", "Explore Education Statistics")),
+              ),
+              
+              br(),
+              conditionalPanel(condition = "input.ts_choice == 'Year to date'",
+                               p(strong(paste0("Attendance and absence across year to date")))),
+              conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_attendance_rate_nat"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_attendance_rate_reg"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_attendance_rate_la"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_absence_rate_nat"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_absence_rate_reg"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_absence_rate_la"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_illness_rate_nat"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_illness_rate_reg"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Year to date'", 
+                               textOutput("ytd_illness_rate_la"
+                               )),
+              conditionalPanel(condition = "input.ts_choice == 'Most recent week'",
+                               p(strong(paste0("Attendance and absence in the most recent week")))),
+              conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_attendance_rate_nat"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_attendance_rate_reg"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_attendance_rate_la"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_absence_rate_nat"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_absence_rate_reg"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_absence_rate_la"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'National' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_illness_rate_nat"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Regional' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_illness_rate_reg"
+                               )),
+              conditionalPanel(condition = "input.geography_choice == 'Local authority' && input.ts_choice == 'Most recent week'", 
+                               textOutput("weekly_illness_rate_la"
+                               )),
+              br(),
+              h5(textOutput("headline_ts_chart_title")),
+              conditionalPanel(condition = "input.ts_choice == 'Year to date'", 
+                               plotlyOutput("absence_rates_timeseries_plot")),
+              conditionalPanel(condition = "input.ts_choice == 'Most recent week'", 
+                               plotlyOutput("absence_rates_daily_plot")),
+              
+            ),
+          )
+        ),
+        tabPanel(
+          value = "reasons",
+          title = "Reasons",
+          fluidRow(
             br(),
-            h4(textOutput("la_comparison_title")),
-            DTOutput("absence_reasons_la_table")
+            br(),
+            conditionalPanel(condition = "input.geography_choice == 'National'", 
+                             h4(textOutput("reasons_chart_title_nat"
+                             ))),
+            conditionalPanel(condition = "input.geography_choice == 'Regional'", 
+                             h4(textOutput("reasons_chart_title_reg"
+                             ))),
+            conditionalPanel(condition = "input.geography_choice == 'Local authority'", 
+                             h4(textOutput("reasons_chart_title_la"
+                             )))
+          ),
+          fluidRow(
+            conditionalPanel(condition = "input.ts_choice == 'Most recent week'",
+                             column(9,
+                                    br(),
+                                    plotlyOutput("absence_reasons_daily_plot")),
+                             column(3,
+                                    fluidRow(
+                                      
+                                      br(),
+                                      p(strong(paste0("Authorised absence rate:"))),
+                                      shinydashboard::valueBoxOutput("headline_auth_rate_weekly", width = 12)
+                                    ),
+                                    fluidRow(
+                                      br(),
+                                      p(strong(paste0("Unauthorised absence rate:"))),
+                                      shinydashboard::valueBoxOutput("headline_unauth_rate_weekly", width = 12)
+                                    )
+                             )
+            ),
+            conditionalPanel(condition = "input.ts_choice == 'Year to date'",
+                             column(9,
+                                    br(),
+                                    plotlyOutput("absence_reasons_timeseries_plot")),
+                             column(3,
+                                    fluidRow(
+                                      
+                                      br(),
+                                      p(strong(paste0("Authorised absence rate:"))),
+                                      shinydashboard::valueBoxOutput("headline_auth_rate_ytd", width = 12)
+                                    ),
+                                    fluidRow(
+                                      br(),
+                                      p(strong(paste0("Unauthorised absence rate:"))),
+                                      shinydashboard::valueBoxOutput("headline_unauth_rate_ytd", width = 12)
+                                    )
+                             )
+            )
+          ),
+          br(),
+          conditionalPanel(condition = "input.ts_choice == 'Most recent week'",
+                           p(strong("Reasons for absence in the most recent week")),
+                           p("Authorised absence"),
+                           DTOutput("absence_auth_reasons_table"),
+                           br(),
+                           br(),
+                           p("Unauthorised absence"),
+                           DTOutput("absence_unauth_reasons_table")),
+          conditionalPanel(condition = "input.ts_choice == 'Year to date'",
+                           p(strong("Reasons for absence in the year to date")),
+                           p("Authorised absence"),
+                           DTOutput("absence_auth_reasons_table_ytd"),
+                           br(),
+                           br(),
+                           p("Unauthorised absence"),
+                           DTOutput("absence_unauth_reasons_table_ytd")),
+        ),
+        tabPanel(
+          value = "la comparisons",
+          title = "Local Authority Data",
+          fluidPage(
+            fluidRow(
+              br(),
+              h4(textOutput("map_title")),
+              textOutput("la_clarity_dates"),
+              fluidRow(
+                column(
+                  3,
+                  br(),
+                  p(strong("Select absence rate of interest from drop down menu to view on the map:")),
+                ),
+                column(
+                  3,
+                  selectInput(inputId = "measure_choice",
+                              label = "Choose measure of interest:",
+                              choices = c("Overall", "Authorised","Unauthorised")
+                  )
+                ),
+              ),
+              leafletOutput("rates_map"),
+              br(),
+              h4(textOutput("la_comparison_title")),
+              DTOutput("absence_reasons_la_table")
+            )
           )
         )
       )
+      # add box to show user input
     )
-    # add box to show user input
-  )
   )
 }
 
@@ -393,19 +420,19 @@ notes_panel <- function(){
       referrer = "no-referrer"
     ),
     gov_main_layout(
-    h2("Technical notes"),
-    br("The dashboard provides data on attendance and absence at National, Regional and Local Authority geographic levels. Data is available across state-funded primary, secondary and special schools and can also be broken down by individual school type. Drop-down menus at the top of the page allow customisation of breakdowns."),
-    br(),
-    p("Users should be aware"),
-    p("• Estimates for non-response - In recognition that response rates are not equal across school types and, therefore, not representative of the total school population, the total rates for all schools has been weighted based on the Spring 2022 school census. Weighted total figures are not included at local authority level due to the low number of schools involved."),
-    p("• Reporting lag - Schools update their registers continually and attendance codes change, resulting in absence rates for a particular day to decrease over time. Analysis of data from the Summer 2022 term suggests that this could be a decrease in the absence rate of around 1 percentage point before settling down. Historical figures will be recalculated in each publication."),
-    p("• Data prior to 12 September 2022 has not been included in the dashboard due to the impact of different start dates, inset days and phased returns. National level estimates covering the week commencing 5 September is available at the link below: "),
-    a(href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools", "Pupil attendance in schools"),
-    br(),
-    br(),
-    p("Full information on methodologies and further technical notes are available through", a(href = "https://explore-education-statistics.service.gov.uk/methodology/pupil-attendance-in-schools", "Explore Education Statistics")),
-    br()
-  )
+      h2("Technical notes"),
+      br("The dashboard provides data on attendance and absence at National, Regional and Local Authority geographic levels. Data is available across state-funded primary, secondary and special schools and can also be broken down by individual school type. Drop-down menus at the top of the page allow customisation of breakdowns."),
+      br(),
+      p("Users should be aware"),
+      p("• Estimates for non-response - In recognition that response rates are not equal across school types and, therefore, not representative of the total school population, the total rates for all schools has been weighted based on the Spring 2022 school census. Weighted total figures are not included at local authority level due to the low number of schools involved."),
+      p("• Reporting lag - Schools update their registers continually and attendance codes change, resulting in absence rates for a particular day to decrease over time. Analysis of data from the Summer 2022 term suggests that this could be a decrease in the absence rate of around 1 percentage point before settling down. Historical figures will be recalculated in each publication."),
+      p("• Data prior to 12 September 2022 has not been included in the dashboard due to the impact of different start dates, inset days and phased returns. National level estimates covering the week commencing 5 September is available at the link below: "),
+      a(href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools", "Pupil attendance in schools"),
+      br(),
+      br(),
+      p("Full information on methodologies and further technical notes are available through", a(href = "https://explore-education-statistics.service.gov.uk/methodology/pupil-attendance-in-schools", "Explore Education Statistics")),
+      br()
+    )
   )
 }
 
@@ -414,27 +441,27 @@ accessibility_panel <- function(){
   tabPanel(
     "Accessibility",
     gov_main_layout(
-    h2("Accessibility statement"),
-    br("This accessibility statement applies to the Pupil attendance in schools in England data dashboard.
+      h2("Accessibility statement"),
+      br("This accessibility statement applies to the Pupil attendance in schools in England data dashboard.
             This application is run by the Department for Education. We want as many people as possible to be able to use this application,
             and have actively developed this application with accessibilty in mind."),
-    h3("WCAG 2.1 compliance"),
-    br("We follow the reccomendations of the ", a(href = "https://www.w3.org/TR/WCAG21/", "WCAG 2.1 requirements. ", onclick = "ga('send', 'event', 'click', 'link', 'IKnow', 1)"), "This application has been checked using the ", a(href = "https://github.com/ewenme/shinya11y", "Shinya11y tool "), ", which did not detect accessibility issues.
+      h3("WCAG 2.1 compliance"),
+      br("We follow the reccomendations of the ", a(href = "https://www.w3.org/TR/WCAG21/", "WCAG 2.1 requirements. ", onclick = "ga('send', 'event', 'click', 'link', 'IKnow', 1)"), "This application has been checked using the ", a(href = "https://github.com/ewenme/shinya11y", "Shinya11y tool "), ", which did not detect accessibility issues.
              This application also fully passes the accessibility audits checked by the ", a(href = "https://developers.google.com/web/tools/lighthouse", "Google Developer Lighthouse tool"), ". This means that this application:"),
-    tags$div(tags$ul(
-      tags$li("uses colours that have sufficient contrast"),
-      tags$li("allows you to zoom in up to 300% without the text spilling off the screen"),
-      tags$li("has its performance regularly monitored, with a team working on any feedback to improve accessibility for all users")
-    )),
-    h3("Limitations"),
-    br("We recognise that there are still potential issues with accessibility in this application, but we will continue
+      tags$div(tags$ul(
+        tags$li("uses colours that have sufficient contrast"),
+        tags$li("allows you to zoom in up to 300% without the text spilling off the screen"),
+        tags$li("has its performance regularly monitored, with a team working on any feedback to improve accessibility for all users")
+      )),
+      h3("Limitations"),
+      br("We recognise that there are still potential issues with accessibility in this application, but we will continue
              to review updates to technology available to us to keep improving accessibility for all of our users."),
-    h3("Feedback"),
-    br(
-      "If you have any feedback on how we could further improve the accessibility of this application, please contact us at",
-      a(href = "mailto:schools.statistics@education.gov.uk", "schools.statistics@education.gov.uk")
+      h3("Feedback"),
+      br(
+        "If you have any feedback on how we could further improve the accessibility of this application, please contact us at",
+        a(href = "mailto:schools.statistics@education.gov.uk", "schools.statistics@education.gov.uk")
+      )
     )
-  )
   )
 }
 

--- a/server.R
+++ b/server.R
@@ -325,6 +325,76 @@ server <- function(input, output, session) {
   })
 
 
+  # YTD data for reasons tables
+  live_attendance_data_ytd_reasons_tables <- reactive({
+    if (input$geography_choice == "National") {
+      dplyr::filter(
+        attendance_data, geographic_level == "National",
+        school_type == input$school_choice,
+        time_period == max(time_period),
+        breakdown == "YTD"
+      ) %>% mutate(
+        illness_perc = illness_perc / 100,
+        appointments_perc = appointments_perc / 100,
+        auth_religious_perc = auth_religious_perc / 100,
+        auth_study_perc = auth_study_perc / 100,
+        auth_grt_perc = auth_grt_perc / 100,
+        auth_holiday_perc = auth_holiday_perc / 100,
+        auth_excluded_perc = auth_excluded_perc / 100,
+        auth_other_perc = auth_other_perc / 100,
+        unauth_hol_perc = unauth_hol_perc / 100,
+        unauth_late_registers_closed_perc = unauth_late_registers_closed_perc / 100,
+        unauth_oth_perc = unauth_oth_perc / 100,
+        unauth_not_yet_perc = unauth_not_yet_perc / 100
+      )
+    } else if (input$geography_choice == "Regional") {
+      dplyr::filter(
+        attendance_data, geographic_level == "Regional",
+        region_name == input$region_choice,
+        school_type == input$school_choice,
+        time_period == max(time_period),
+        breakdown == "YTD"
+      ) %>% mutate(
+        illness_perc = illness_perc / 100,
+        appointments_perc = appointments_perc / 100,
+        auth_religious_perc = auth_religious_perc / 100,
+        auth_study_perc = auth_study_perc / 100,
+        auth_grt_perc = auth_grt_perc / 100,
+        auth_holiday_perc = auth_holiday_perc / 100,
+        auth_excluded_perc = auth_excluded_perc / 100,
+        auth_other_perc = auth_other_perc / 100,
+        unauth_hol_perc = unauth_hol_perc / 100,
+        unauth_late_registers_closed_perc = unauth_late_registers_closed_perc / 100,
+        unauth_oth_perc = unauth_oth_perc / 100,
+        unauth_not_yet_perc = unauth_not_yet_perc / 100
+      )
+    } else if (input$geography_choice == "Local authority") {
+      dplyr::filter(
+        attendance_data, geographic_level == "Local authority",
+        region_name == input$region_choice,
+        la_name == input$la_choice,
+        school_type == input$school_choice,
+        time_period == max(time_period),
+        breakdown == "YTD"
+      ) %>% mutate(
+        illness_perc = illness_perc / 100,
+        appointments_perc = appointments_perc / 100,
+        auth_religious_perc = auth_religious_perc / 100,
+        auth_study_perc = auth_study_perc / 100,
+        auth_grt_perc = auth_grt_perc / 100,
+        auth_holiday_perc = auth_holiday_perc / 100,
+        auth_excluded_perc = auth_excluded_perc / 100,
+        auth_other_perc = auth_other_perc / 100,
+        unauth_hol_perc = unauth_hol_perc / 100,
+        unauth_late_registers_closed_perc = unauth_late_registers_closed_perc / 100,
+        unauth_oth_perc = unauth_oth_perc / 100,
+        unauth_not_yet_perc = unauth_not_yet_perc / 100
+      )
+    } else {
+      NA
+    }
+  })
+
   # Weekly data for local authority comparisons table
   live_attendance_data_weekly_las <- reactive({
     filter(
@@ -664,7 +734,7 @@ server <- function(input, output, session) {
       type = "scatter", mode = "lines+markers"
     ) %>%
       add_trace(
-        x = ~attendance_date,
+        x = ~week_commencing,
         y = ~illness_perc,
         line = list(color = "#12436D"),
         marker = list(color = "#12436D"),
@@ -673,7 +743,7 @@ server <- function(input, output, session) {
         mode = "markers"
       ) %>%
       add_trace(
-        x = ~attendance_date,
+        x = ~week_commencing,
         y = ~appointments_perc,
         line = list(color = "#28A197"),
         marker = list(color = "#28A197"),
@@ -682,7 +752,7 @@ server <- function(input, output, session) {
         mode = "markers"
       ) %>%
       add_trace(
-        x = ~attendance_date,
+        x = ~week_commencing,
         y = ~unauth_hol_perc,
         line = list(color = "	#F46A25"),
         marker = list(color = "	#F46A25"),
@@ -691,7 +761,7 @@ server <- function(input, output, session) {
         mode = "markers"
       ) %>%
       add_trace(
-        x = ~attendance_date,
+        x = ~week_commencing,
         y = ~unauth_oth_perc,
         line = list(color = "	#3D3D3D"),
         marker = list(color = "	#3D3D3D"),
@@ -703,7 +773,7 @@ server <- function(input, output, session) {
     reasons_ts_plot <- reasons_ts_plot %>% layout(
       xaxis = list(
         title = "Week commencing",
-        tickvals = ~attendance_date,
+        tickvals = ~week_commencing,
         zeroline = T,
         zerolinewidth = 2,
         zerolinecolor = "Grey",
@@ -734,8 +804,9 @@ server <- function(input, output, session) {
     reasons_ts_plot <- reasons_ts_plot %>% layout(
       xaxis = list(
         tickmode = "linear",
-        tick0 = "2021-08-01",
-        dtick = "M1"
+        tick0 = "2022-09-12",
+        # dtick = "M1"
+        dtick = 86400000 * 7
       ),
       margin = list(t = 80)
     )
@@ -1372,7 +1443,7 @@ server <- function(input, output, session) {
 
   # Creating reactive reasons and la comparison table ------------------------------------------------------------
 
-  # authorised reasons
+  # authorised reasons weekly
   output$absence_auth_reasons_table <- renderDT({
     validate(need(nrow(live_attendance_data_weekly_reasons_tables()) > 0, "There is no data available for this breakdown at present"))
 
@@ -1406,7 +1477,41 @@ server <- function(input, output, session) {
       formatPercentage(c(0:7), 1)
   })
 
-  # unauthorised reasons
+  # authorised reasons ytd
+  output$absence_auth_reasons_table_ytd <- renderDT({
+    validate(need(nrow(live_attendance_data_ytd_reasons_tables()) > 0, "There is no data available for this breakdown at present"))
+
+    absence_auth_reasons_ytd_dt <- live_attendance_data_ytd_reasons_tables() %>%
+      dplyr::select(illness_perc, appointments_perc, auth_religious_perc, auth_study_perc, auth_grt_perc, auth_holiday_perc, auth_excluded_perc, auth_other_perc) %>%
+      rename(
+        "Illness" = illness_perc,
+        "Medical or dental appointments" = appointments_perc,
+        "Religious observance" = auth_religious_perc,
+        "Study leave" = auth_study_perc,
+        "Traveller" = auth_grt_perc,
+        "Holiday" = auth_holiday_perc,
+        "Excluded" = auth_excluded_perc,
+        "Other" = auth_other_perc
+      )
+
+    absence_auth_reasons_ytd_dt <- datatable(absence_auth_reasons_ytd_dt,
+      selection = "none",
+      escape = FALSE,
+      rownames = FALSE,
+      class = "cell-border stripe",
+      options = list(
+        scrollX = TRUE,
+        ordering = F,
+        searching = FALSE,
+        lengthChange = FALSE,
+        dom = "t",
+        columnDefs = list(list(className = "dt-center", targets = 0:7))
+      )
+    ) %>%
+      formatPercentage(c(0:7), 1)
+  })
+
+  # unauthorised reasons weekly
   output$absence_unauth_reasons_table <- renderDT({
     validate(need(nrow(live_attendance_data_weekly_reasons_tables()) > 0, "There is no data available for this breakdown at present"))
 
@@ -1436,6 +1541,35 @@ server <- function(input, output, session) {
       formatPercentage(c(0:3), 1)
   })
 
+  # unauthorised reasons ytd
+  output$absence_unauth_reasons_table_ytd <- renderDT({
+    validate(need(nrow(live_attendance_data_ytd_reasons_tables()) > 0, "There is no data available for this breakdown at present"))
+
+    absence_unauth_reasons_ytd_dt <- live_attendance_data_ytd_reasons_tables() %>%
+      dplyr::select(unauth_hol_perc, unauth_late_registers_closed_perc, unauth_oth_perc, unauth_not_yet_perc) %>%
+      rename(
+        "Holiday" = unauth_hol_perc,
+        "Late after registers closed" = unauth_late_registers_closed_perc,
+        "Other" = unauth_oth_perc,
+        "No reason yet" = unauth_not_yet_perc
+      )
+
+    absence_unauth_reasons_ytd_dt <- datatable(absence_unauth_reasons_ytd_dt,
+      selection = "none",
+      escape = FALSE,
+      rownames = FALSE,
+      class = "cell-border stripe",
+      options = list(
+        scrollX = TRUE,
+        ordering = F,
+        searching = FALSE,
+        lengthChange = FALSE,
+        dom = "t",
+        columnDefs = list(list(className = "dt-center", targets = 0:3))
+      )
+    ) %>%
+      formatPercentage(c(0:3), 1)
+  })
 
   # absence reasons by local authority
   output$absence_reasons_la_table <- renderDT({

--- a/tests/shinytest/UI_tests-expected/008.json
+++ b/tests/shinytest/UI_tests-expected/008.json
@@ -12,127 +12,346 @@
     "ts_choice": "Year to date"
   },
   "output": {
-    "absence_auth_reasons_table": {
+    "absence_reasons_timeseries_plot": {
       "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Illness<\/th>\n      <th>Medical or dental appointments<\/th>\n      <th>Religious observance<\/th>\n      <th>Study leave<\/th>\n      <th>Traveller<\/th>\n      <th>Holiday<\/th>\n      <th>Excluded<\/th>\n      <th>Other<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 3,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 4,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 5,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 6,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 80,
+            "r": 10
           },
-          "serverSide": true,
-          "processing": true
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "Week commencing",
+            "tickvals": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey",
+            "tickmode": "linear",
+            "tick0": "2022-09-12",
+            "dtick": 604800000
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "rangemode": "tozero",
+            "title": "Absence rate (%)",
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey"
+          },
+          "hovermode": "x unified",
+          "legend": {
+            "font": {
+              "size": 11
+            },
+            "orientation": "h",
+            "yanchor": "top",
+            "y": -0.5,
+            "xanchor": "center",
+            "x": 0.5
+          },
+          "title": "Weekly summary of absence reasons for <br>primary state-funded schools<br>at national level",
+          "font": {
+            "family": "arial",
+            "size": 10,
+            "color": "grey"
+          },
+          "showlegend": true
         },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
+        "source": "A",
+        "config": {
+          "modeBarButtonsToAdd": [
+            "hoverclosest",
+            "hovercompare"
+          ],
+          "showSendToCloud": false
+        },
+        "data": [
+          {
+            "mode": "lines+markers",
+            "type": "scatter",
+            "marker": {
+              "color": "rgba(31,119,180,1)",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "line": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              2.32239864533528,
+              2.97983858135342,
+              2.92164443104633,
+              3.0288143547274,
+              3.2477507835679
+            ],
+            "line": {
+              "color": "#12436D"
+            },
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "name": "Illness",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.210827484279873,
+              0.217009793137102,
+              0.222492293265079,
+              0.223370600414079,
+              0.22356688231511
+            ],
+            "line": {
+              "color": "#28A197"
+            },
+            "marker": {
+              "color": "#28A197",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "name": "Medical appointments",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.572264526617437,
+              0.505541357589946,
+              0.518907155342735,
+              0.512979066022544,
+              0.553184816149546
+            ],
+            "line": {
+              "color": "\t#F46A25"
+            },
+            "marker": {
+              "color": "\t#F46A25",
+              "line": {
+                "color": "rgba(214,39,40,1)"
+              }
+            },
+            "name": "Unauthorised holiday",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "error_x": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.621054476302154,
+              0.603786359898365,
+              0.588772773543297,
+              0.588072693811824,
+              0.577880171896486
+            ],
+            "line": {
+              "color": "\t#3D3D3D"
+            },
+            "marker": {
+              "color": "\t#3D3D3D",
+              "line": {
+                "color": "rgba(148,103,189,1)"
+              }
+            },
+            "name": "Unauthorised other",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "error_x": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
       },
       "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.columnDefs.4.render",
-        "options.columnDefs.5.render",
-        "options.columnDefs.6.render",
-        "options.columnDefs.7.render",
-        "options.ajax.data"
+
       ],
       "jsHooks": [
 
       ],
       "deps": [
         {
-          "name": "jquery",
-          "version": "3.6.0",
+          "name": "setprototypeof",
+          "version": "0.1",
           "src": {
-            "href": "jquery-3.6.0"
+            "href": "setprototypeof-0.1"
           },
           "meta": null,
-          "script": "jquery-3.6.0.min.js",
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
           "stylesheet": null,
           "head": null,
           "attachment": null,
           "all_files": true
-        },
-        {
-          "name": "dt-core",
-          "version": "1.11.3",
-          "src": {
-            "href": "dt-core-1.11.3"
-          },
-          "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
-          "head": null,
-          "attachment": null,
-          "package": null,
-          "all_files": false
         },
         {
           "name": "crosstalk",
@@ -146,136 +365,37 @@
           "head": null,
           "attachment": null,
           "all_files": true
-        }
-      ]
-    },
-    "absence_unauth_reasons_table": {
-      "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Holiday<\/th>\n      <th>Late after registers closed<\/th>\n      <th>Other<\/th>\n      <th>No reason yet<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
-          },
-          "serverSide": true,
-          "processing": true
-        },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
-      },
-      "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.ajax.data"
-      ],
-      "jsHooks": [
-
-      ],
-      "deps": [
-        {
-          "name": "jquery",
-          "version": "3.6.0",
-          "src": {
-            "href": "jquery-3.6.0"
-          },
-          "meta": null,
-          "script": "jquery-3.6.0.min.js",
-          "stylesheet": null,
-          "head": null,
-          "attachment": null,
-          "all_files": true
         },
         {
-          "name": "dt-core",
-          "version": "1.11.3",
+          "name": "plotly-htmlwidgets-css",
+          "version": "2.5.1",
           "src": {
-            "href": "dt-core-1.11.3"
+            "href": "plotly-htmlwidgets-css-2.5.1"
           },
           "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
           "head": null,
           "attachment": null,
-          "package": null,
           "all_files": false
         },
         {
-          "name": "crosstalk",
-          "version": "1.2.0",
+          "name": "plotly-main",
+          "version": "2.5.1",
           "src": {
-            "href": "crosstalk-1.2.0"
+            "href": "plotly-main-2.5.1"
           },
           "meta": null,
-          "script": "js/crosstalk.min.js",
-          "stylesheet": "css/crosstalk.min.css",
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
           "head": null,
           "attachment": null,
-          "all_files": true
+          "all_files": false
         }
-      ]
-    },
-    "headline_auth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>3.9%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
       ]
     },
     "headline_auth_rate_ytd": {
       "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>3.5%<\/h3>\n    <p>Year to date<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
-      ]
-    },
-    "headline_unauth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>1.4%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
       "deps": [
 
       ]

--- a/tests/shinytest/UI_tests-expected/009.json
+++ b/tests/shinytest/UI_tests-expected/009.json
@@ -12,127 +12,346 @@
     "ts_choice": "Year to date"
   },
   "output": {
-    "absence_auth_reasons_table": {
+    "absence_reasons_timeseries_plot": {
       "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Illness<\/th>\n      <th>Medical or dental appointments<\/th>\n      <th>Religious observance<\/th>\n      <th>Study leave<\/th>\n      <th>Traveller<\/th>\n      <th>Holiday<\/th>\n      <th>Excluded<\/th>\n      <th>Other<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 3,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 4,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 5,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 6,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 80,
+            "r": 10
           },
-          "serverSide": true,
-          "processing": true
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "Week commencing",
+            "tickvals": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey",
+            "tickmode": "linear",
+            "tick0": "2022-09-12",
+            "dtick": 604800000
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "rangemode": "tozero",
+            "title": "Absence rate (%)",
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey"
+          },
+          "hovermode": "x unified",
+          "legend": {
+            "font": {
+              "size": 11
+            },
+            "orientation": "h",
+            "yanchor": "top",
+            "y": -0.5,
+            "xanchor": "center",
+            "x": 0.5
+          },
+          "title": "Weekly summary of absence reasons for <br>secondary state-funded schools<br>at national level",
+          "font": {
+            "family": "arial",
+            "size": 10,
+            "color": "grey"
+          },
+          "showlegend": true
         },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
+        "source": "A",
+        "config": {
+          "modeBarButtonsToAdd": [
+            "hoverclosest",
+            "hovercompare"
+          ],
+          "showSendToCloud": false
+        },
+        "data": [
+          {
+            "mode": "lines+markers",
+            "type": "scatter",
+            "marker": {
+              "color": "rgba(31,119,180,1)",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "line": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              2.85001978851238,
+              4.21693378914535,
+              4.51666597096204,
+              3.8204231360797,
+              3.54075878808104
+            ],
+            "line": {
+              "color": "#12436D"
+            },
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "name": "Illness",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.292710678266349,
+              0.315342384161458,
+              0.321264014823103,
+              0.325535998140074,
+              0.330916365514814
+            ],
+            "line": {
+              "color": "#28A197"
+            },
+            "marker": {
+              "color": "#28A197",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "name": "Medical appointments",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.371283215759582,
+              0.313275111530901,
+              0.310608491943398,
+              0.307629118906624,
+              0.354063200954272
+            ],
+            "line": {
+              "color": "\t#F46A25"
+            },
+            "marker": {
+              "color": "\t#F46A25",
+              "line": {
+                "color": "rgba(214,39,40,1)"
+              }
+            },
+            "name": "Unauthorised holiday",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "error_x": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              1.76268024857245,
+              1.94782129828917,
+              1.99678144554779,
+              1.94842711055488,
+              1.94128173979944
+            ],
+            "line": {
+              "color": "\t#3D3D3D"
+            },
+            "marker": {
+              "color": "\t#3D3D3D",
+              "line": {
+                "color": "rgba(148,103,189,1)"
+              }
+            },
+            "name": "Unauthorised other",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "error_x": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
       },
       "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.columnDefs.4.render",
-        "options.columnDefs.5.render",
-        "options.columnDefs.6.render",
-        "options.columnDefs.7.render",
-        "options.ajax.data"
+
       ],
       "jsHooks": [
 
       ],
       "deps": [
         {
-          "name": "jquery",
-          "version": "3.6.0",
+          "name": "setprototypeof",
+          "version": "0.1",
           "src": {
-            "href": "jquery-3.6.0"
+            "href": "setprototypeof-0.1"
           },
           "meta": null,
-          "script": "jquery-3.6.0.min.js",
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
           "stylesheet": null,
           "head": null,
           "attachment": null,
           "all_files": true
-        },
-        {
-          "name": "dt-core",
-          "version": "1.11.3",
-          "src": {
-            "href": "dt-core-1.11.3"
-          },
-          "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
-          "head": null,
-          "attachment": null,
-          "package": null,
-          "all_files": false
         },
         {
           "name": "crosstalk",
@@ -146,136 +365,37 @@
           "head": null,
           "attachment": null,
           "all_files": true
-        }
-      ]
-    },
-    "absence_unauth_reasons_table": {
-      "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Holiday<\/th>\n      <th>Late after registers closed<\/th>\n      <th>Other<\/th>\n      <th>No reason yet<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
-          },
-          "serverSide": true,
-          "processing": true
-        },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
-      },
-      "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.ajax.data"
-      ],
-      "jsHooks": [
-
-      ],
-      "deps": [
-        {
-          "name": "jquery",
-          "version": "3.6.0",
-          "src": {
-            "href": "jquery-3.6.0"
-          },
-          "meta": null,
-          "script": "jquery-3.6.0.min.js",
-          "stylesheet": null,
-          "head": null,
-          "attachment": null,
-          "all_files": true
         },
         {
-          "name": "dt-core",
-          "version": "1.11.3",
+          "name": "plotly-htmlwidgets-css",
+          "version": "2.5.1",
           "src": {
-            "href": "dt-core-1.11.3"
+            "href": "plotly-htmlwidgets-css-2.5.1"
           },
           "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
           "head": null,
           "attachment": null,
-          "package": null,
           "all_files": false
         },
         {
-          "name": "crosstalk",
-          "version": "1.2.0",
+          "name": "plotly-main",
+          "version": "2.5.1",
           "src": {
-            "href": "crosstalk-1.2.0"
+            "href": "plotly-main-2.5.1"
           },
           "meta": null,
-          "script": "js/crosstalk.min.js",
-          "stylesheet": "css/crosstalk.min.css",
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
           "head": null,
           "attachment": null,
-          "all_files": true
+          "all_files": false
         }
-      ]
-    },
-    "headline_auth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>4.7%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
       ]
     },
     "headline_auth_rate_ytd": {
       "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>4.9%<\/h3>\n    <p>Year to date<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
-      ]
-    },
-    "headline_unauth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>2.8%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
       "deps": [
 
       ]

--- a/tests/shinytest/UI_tests-expected/010.json
+++ b/tests/shinytest/UI_tests-expected/010.json
@@ -12,127 +12,346 @@
     "ts_choice": "Year to date"
   },
   "output": {
-    "absence_auth_reasons_table": {
+    "absence_reasons_timeseries_plot": {
       "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Illness<\/th>\n      <th>Medical or dental appointments<\/th>\n      <th>Religious observance<\/th>\n      <th>Study leave<\/th>\n      <th>Traveller<\/th>\n      <th>Holiday<\/th>\n      <th>Excluded<\/th>\n      <th>Other<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 3,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 4,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 5,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 6,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 80,
+            "r": 10
           },
-          "serverSide": true,
-          "processing": true
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "Week commencing",
+            "tickvals": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey",
+            "tickmode": "linear",
+            "tick0": "2022-09-12",
+            "dtick": 604800000
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "rangemode": "tozero",
+            "title": "Absence rate (%)",
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey"
+          },
+          "hovermode": "x unified",
+          "legend": {
+            "font": {
+              "size": 11
+            },
+            "orientation": "h",
+            "yanchor": "top",
+            "y": -0.5,
+            "xanchor": "center",
+            "x": 0.5
+          },
+          "title": "Weekly summary of absence reasons for <br>primary state-funded schools at regional level<br>(East Midlands)",
+          "font": {
+            "family": "arial",
+            "size": 10,
+            "color": "grey"
+          },
+          "showlegend": true
         },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
+        "source": "A",
+        "config": {
+          "modeBarButtonsToAdd": [
+            "hoverclosest",
+            "hovercompare"
+          ],
+          "showSendToCloud": false
+        },
+        "data": [
+          {
+            "mode": "lines+markers",
+            "type": "scatter",
+            "marker": {
+              "color": "rgba(31,119,180,1)",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "line": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              2.38535927956038,
+              2.81608716740237,
+              2.85324811440256,
+              2.98543794565944,
+              3.40524802116206
+            ],
+            "line": {
+              "color": "#12436D"
+            },
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "name": "Illness",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.208813614804393,
+              0.208381305126735,
+              0.21021812702679,
+              0.21139643141873,
+              0.2132543579623
+            ],
+            "line": {
+              "color": "#28A197"
+            },
+            "marker": {
+              "color": "#28A197",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "name": "Medical appointments",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.555704525034998,
+              0.511916873932032,
+              0.53240398402788,
+              0.518616752952531,
+              0.895989836092214
+            ],
+            "line": {
+              "color": "\t#F46A25"
+            },
+            "marker": {
+              "color": "\t#F46A25",
+              "line": {
+                "color": "rgba(214,39,40,1)"
+              }
+            },
+            "name": "Unauthorised holiday",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "error_x": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.589614428293831,
+              0.578546632938073,
+              0.554008783379737,
+              0.548068002333775,
+              0.597920378956644
+            ],
+            "line": {
+              "color": "\t#3D3D3D"
+            },
+            "marker": {
+              "color": "\t#3D3D3D",
+              "line": {
+                "color": "rgba(148,103,189,1)"
+              }
+            },
+            "name": "Unauthorised other",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "error_x": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
       },
       "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.columnDefs.4.render",
-        "options.columnDefs.5.render",
-        "options.columnDefs.6.render",
-        "options.columnDefs.7.render",
-        "options.ajax.data"
+
       ],
       "jsHooks": [
 
       ],
       "deps": [
         {
-          "name": "jquery",
-          "version": "3.6.0",
+          "name": "setprototypeof",
+          "version": "0.1",
           "src": {
-            "href": "jquery-3.6.0"
+            "href": "setprototypeof-0.1"
           },
           "meta": null,
-          "script": "jquery-3.6.0.min.js",
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
           "stylesheet": null,
           "head": null,
           "attachment": null,
           "all_files": true
-        },
-        {
-          "name": "dt-core",
-          "version": "1.11.3",
-          "src": {
-            "href": "dt-core-1.11.3"
-          },
-          "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
-          "head": null,
-          "attachment": null,
-          "package": null,
-          "all_files": false
         },
         {
           "name": "crosstalk",
@@ -146,136 +365,37 @@
           "head": null,
           "attachment": null,
           "all_files": true
-        }
-      ]
-    },
-    "absence_unauth_reasons_table": {
-      "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Holiday<\/th>\n      <th>Late after registers closed<\/th>\n      <th>Other<\/th>\n      <th>No reason yet<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
-          },
-          "serverSide": true,
-          "processing": true
-        },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
-      },
-      "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.ajax.data"
-      ],
-      "jsHooks": [
-
-      ],
-      "deps": [
-        {
-          "name": "jquery",
-          "version": "3.6.0",
-          "src": {
-            "href": "jquery-3.6.0"
-          },
-          "meta": null,
-          "script": "jquery-3.6.0.min.js",
-          "stylesheet": null,
-          "head": null,
-          "attachment": null,
-          "all_files": true
         },
         {
-          "name": "dt-core",
-          "version": "1.11.3",
+          "name": "plotly-htmlwidgets-css",
+          "version": "2.5.1",
           "src": {
-            "href": "dt-core-1.11.3"
+            "href": "plotly-htmlwidgets-css-2.5.1"
           },
           "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
           "head": null,
           "attachment": null,
-          "package": null,
           "all_files": false
         },
         {
-          "name": "crosstalk",
-          "version": "1.2.0",
+          "name": "plotly-main",
+          "version": "2.5.1",
           "src": {
-            "href": "crosstalk-1.2.0"
+            "href": "plotly-main-2.5.1"
           },
           "meta": null,
-          "script": "js/crosstalk.min.js",
-          "stylesheet": "css/crosstalk.min.css",
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
           "head": null,
           "attachment": null,
-          "all_files": true
+          "all_files": false
         }
-      ]
-    },
-    "headline_auth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>4.1%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
       ]
     },
     "headline_auth_rate_ytd": {
       "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>3.5%<\/h3>\n    <p>Year to date<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
-      ]
-    },
-    "headline_unauth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>1.8%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
       "deps": [
 
       ]

--- a/tests/shinytest/UI_tests-expected/011.json
+++ b/tests/shinytest/UI_tests-expected/011.json
@@ -12,127 +12,346 @@
     "ts_choice": "Year to date"
   },
   "output": {
-    "absence_auth_reasons_table": {
+    "absence_reasons_timeseries_plot": {
       "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Illness<\/th>\n      <th>Medical or dental appointments<\/th>\n      <th>Religious observance<\/th>\n      <th>Study leave<\/th>\n      <th>Traveller<\/th>\n      <th>Holiday<\/th>\n      <th>Excluded<\/th>\n      <th>Other<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 3,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 4,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 5,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 6,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 80,
+            "r": 10
           },
-          "serverSide": true,
-          "processing": true
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "Week commencing",
+            "tickvals": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey",
+            "tickmode": "linear",
+            "tick0": "2022-09-12",
+            "dtick": 604800000
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "rangemode": "tozero",
+            "title": "Absence rate (%)",
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey"
+          },
+          "hovermode": "x unified",
+          "legend": {
+            "font": {
+              "size": 11
+            },
+            "orientation": "h",
+            "yanchor": "top",
+            "y": -0.5,
+            "xanchor": "center",
+            "x": 0.5
+          },
+          "title": "Weekly summary of absence reasons for <br>primary state-funded schools at local authority level<br>(East Midlands, Lincolnshire)",
+          "font": {
+            "family": "arial",
+            "size": 10,
+            "color": "grey"
+          },
+          "showlegend": true
         },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
+        "source": "A",
+        "config": {
+          "modeBarButtonsToAdd": [
+            "hoverclosest",
+            "hovercompare"
+          ],
+          "showSendToCloud": false
+        },
+        "data": [
+          {
+            "mode": "lines+markers",
+            "type": "scatter",
+            "marker": {
+              "color": "rgba(31,119,180,1)",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "line": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              2.40805809323026,
+              3.10807798487628,
+              3.18572837273158,
+              3.09549868179147,
+              3.35587964559478
+            ],
+            "line": {
+              "color": "#12436D"
+            },
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "name": "Illness",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.2044837611784,
+              0.202678372400075,
+              0.225275533497137,
+              0.219701421724292,
+              0.230260210329669
+            ],
+            "line": {
+              "color": "#28A197"
+            },
+            "marker": {
+              "color": "#28A197",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "name": "Medical appointments",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.517272263789564,
+              0.506181518887498,
+              0.539081355248893,
+              0.529439990511055,
+              0.537092801924628
+            ],
+            "line": {
+              "color": "\t#F46A25"
+            },
+            "marker": {
+              "color": "\t#F46A25",
+              "line": {
+                "color": "rgba(214,39,40,1)"
+              }
+            },
+            "name": "Unauthorised holiday",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "error_x": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.469044961624847,
+              0.441708534096949,
+              0.423583379187483,
+              0.430237385364381,
+              0.358966978839412
+            ],
+            "line": {
+              "color": "\t#3D3D3D"
+            },
+            "marker": {
+              "color": "\t#3D3D3D",
+              "line": {
+                "color": "rgba(148,103,189,1)"
+              }
+            },
+            "name": "Unauthorised other",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "error_x": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
       },
       "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.columnDefs.4.render",
-        "options.columnDefs.5.render",
-        "options.columnDefs.6.render",
-        "options.columnDefs.7.render",
-        "options.ajax.data"
+
       ],
       "jsHooks": [
 
       ],
       "deps": [
         {
-          "name": "jquery",
-          "version": "3.6.0",
+          "name": "setprototypeof",
+          "version": "0.1",
           "src": {
-            "href": "jquery-3.6.0"
+            "href": "setprototypeof-0.1"
           },
           "meta": null,
-          "script": "jquery-3.6.0.min.js",
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
           "stylesheet": null,
           "head": null,
           "attachment": null,
           "all_files": true
-        },
-        {
-          "name": "dt-core",
-          "version": "1.11.3",
-          "src": {
-            "href": "dt-core-1.11.3"
-          },
-          "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
-          "head": null,
-          "attachment": null,
-          "package": null,
-          "all_files": false
         },
         {
           "name": "crosstalk",
@@ -146,136 +365,37 @@
           "head": null,
           "attachment": null,
           "all_files": true
-        }
-      ]
-    },
-    "absence_unauth_reasons_table": {
-      "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Holiday<\/th>\n      <th>Late after registers closed<\/th>\n      <th>Other<\/th>\n      <th>No reason yet<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
-          },
-          "serverSide": true,
-          "processing": true
-        },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
-      },
-      "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.ajax.data"
-      ],
-      "jsHooks": [
-
-      ],
-      "deps": [
-        {
-          "name": "jquery",
-          "version": "3.6.0",
-          "src": {
-            "href": "jquery-3.6.0"
-          },
-          "meta": null,
-          "script": "jquery-3.6.0.min.js",
-          "stylesheet": null,
-          "head": null,
-          "attachment": null,
-          "all_files": true
         },
         {
-          "name": "dt-core",
-          "version": "1.11.3",
+          "name": "plotly-htmlwidgets-css",
+          "version": "2.5.1",
           "src": {
-            "href": "dt-core-1.11.3"
+            "href": "plotly-htmlwidgets-css-2.5.1"
           },
           "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
           "head": null,
           "attachment": null,
-          "package": null,
           "all_files": false
         },
         {
-          "name": "crosstalk",
-          "version": "1.2.0",
+          "name": "plotly-main",
+          "version": "2.5.1",
           "src": {
-            "href": "crosstalk-1.2.0"
+            "href": "plotly-main-2.5.1"
           },
           "meta": null,
-          "script": "js/crosstalk.min.js",
-          "stylesheet": "css/crosstalk.min.css",
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
           "head": null,
           "attachment": null,
-          "all_files": true
+          "all_files": false
         }
-      ]
-    },
-    "headline_auth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>4%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
       ]
     },
     "headline_auth_rate_ytd": {
       "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>3.7%<\/h3>\n    <p>Year to date<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
-      ]
-    },
-    "headline_unauth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>1.1%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
       "deps": [
 
       ]

--- a/tests/shinytest/UI_tests-expected/012.json
+++ b/tests/shinytest/UI_tests-expected/012.json
@@ -12,127 +12,346 @@
     "ts_choice": "Year to date"
   },
   "output": {
-    "absence_auth_reasons_table": {
+    "absence_reasons_timeseries_plot": {
       "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Illness<\/th>\n      <th>Medical or dental appointments<\/th>\n      <th>Religious observance<\/th>\n      <th>Study leave<\/th>\n      <th>Traveller<\/th>\n      <th>Holiday<\/th>\n      <th>Excluded<\/th>\n      <th>Other<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 3,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 4,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 5,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 6,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
+        "layout": {
+          "margin": {
+            "b": 40,
+            "l": 60,
+            "t": 80,
+            "r": 10
           },
-          "serverSide": true,
-          "processing": true
+          "xaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "title": "Week commencing",
+            "tickvals": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey",
+            "tickmode": "linear",
+            "tick0": "2022-09-12",
+            "dtick": 604800000
+          },
+          "yaxis": {
+            "domain": [
+              0,
+              1
+            ],
+            "automargin": true,
+            "rangemode": "tozero",
+            "title": "Absence rate (%)",
+            "zeroline": true,
+            "zerolinewidth": 2,
+            "zerolinecolor": "Grey"
+          },
+          "hovermode": "x unified",
+          "legend": {
+            "font": {
+              "size": 11
+            },
+            "orientation": "h",
+            "yanchor": "top",
+            "y": -0.5,
+            "xanchor": "center",
+            "x": 0.5
+          },
+          "title": "Weekly summary of absence reasons for <br>primary state-funded schools at local authority level<br>(East Midlands, Lincolnshire)",
+          "font": {
+            "family": "arial",
+            "size": 10,
+            "color": "grey"
+          },
+          "showlegend": true
         },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
+        "source": "A",
+        "config": {
+          "modeBarButtonsToAdd": [
+            "hoverclosest",
+            "hovercompare"
+          ],
+          "showSendToCloud": false
+        },
+        "data": [
+          {
+            "mode": "lines+markers",
+            "type": "scatter",
+            "marker": {
+              "color": "rgba(31,119,180,1)",
+              "line": {
+                "color": "rgba(31,119,180,1)"
+              }
+            },
+            "error_y": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "error_x": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "line": {
+              "color": "rgba(31,119,180,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              2.40805809323026,
+              3.10807798487628,
+              3.18572837273158,
+              3.09549868179147,
+              3.35587964559478
+            ],
+            "line": {
+              "color": "#12436D"
+            },
+            "marker": {
+              "color": "#12436D",
+              "line": {
+                "color": "rgba(255,127,14,1)"
+              }
+            },
+            "name": "Illness",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "error_x": {
+              "color": "rgba(255,127,14,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.2044837611784,
+              0.202678372400075,
+              0.225275533497137,
+              0.219701421724292,
+              0.230260210329669
+            ],
+            "line": {
+              "color": "#28A197"
+            },
+            "marker": {
+              "color": "#28A197",
+              "line": {
+                "color": "rgba(44,160,44,1)"
+              }
+            },
+            "name": "Medical appointments",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "error_x": {
+              "color": "rgba(44,160,44,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.517272263789564,
+              0.506181518887498,
+              0.539081355248893,
+              0.529439990511055,
+              0.537092801924628
+            ],
+            "line": {
+              "color": "\t#F46A25"
+            },
+            "marker": {
+              "color": "\t#F46A25",
+              "line": {
+                "color": "rgba(214,39,40,1)"
+              }
+            },
+            "name": "Unauthorised holiday",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "error_x": {
+              "color": "rgba(214,39,40,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          },
+          {
+            "mode": "markers+lines",
+            "type": "scatter",
+            "x": [
+              "2022-09-12",
+              "2022-09-19",
+              "2022-09-26",
+              "2022-10-03",
+              "2022-10-10"
+            ],
+            "y": [
+              0.469044961624847,
+              0.441708534096949,
+              0.423583379187483,
+              0.430237385364381,
+              0.358966978839412
+            ],
+            "line": {
+              "color": "\t#3D3D3D"
+            },
+            "marker": {
+              "color": "\t#3D3D3D",
+              "line": {
+                "color": "rgba(148,103,189,1)"
+              }
+            },
+            "name": "Unauthorised other",
+            "hovertemplate": [
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%",
+              "%{y:.1f}%"
+            ],
+            "error_y": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "error_x": {
+              "color": "rgba(148,103,189,1)"
+            },
+            "xaxis": "x",
+            "yaxis": "y",
+            "frame": null
+          }
+        ],
+        "highlight": {
+          "on": "plotly_click",
+          "persistent": false,
+          "dynamic": false,
+          "selectize": false,
+          "opacityDim": 0.2,
+          "selected": {
+            "opacity": 1
+          },
+          "debounce": 0
+        },
+        "shinyEvents": [
+          "plotly_hover",
+          "plotly_click",
+          "plotly_selected",
+          "plotly_relayout",
+          "plotly_brushed",
+          "plotly_brushing",
+          "plotly_clickannotation",
+          "plotly_doubleclick",
+          "plotly_deselect",
+          "plotly_afterplot",
+          "plotly_sunburstclick"
+        ],
+        "base_url": "https://plot.ly"
       },
       "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.columnDefs.4.render",
-        "options.columnDefs.5.render",
-        "options.columnDefs.6.render",
-        "options.columnDefs.7.render",
-        "options.ajax.data"
+
       ],
       "jsHooks": [
 
       ],
       "deps": [
         {
-          "name": "jquery",
-          "version": "3.6.0",
+          "name": "setprototypeof",
+          "version": "0.1",
           "src": {
-            "href": "jquery-3.6.0"
+            "href": "setprototypeof-0.1"
           },
           "meta": null,
-          "script": "jquery-3.6.0.min.js",
+          "script": "setprototypeof.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "typedarray",
+          "version": "0.1",
+          "src": {
+            "href": "typedarray-0.1"
+          },
+          "meta": null,
+          "script": "typedarray.min.js",
+          "stylesheet": null,
+          "head": null,
+          "attachment": null,
+          "all_files": false
+        },
+        {
+          "name": "jquery",
+          "version": "3.5.1",
+          "src": {
+            "href": "jquery-3.5.1"
+          },
+          "meta": null,
+          "script": "jquery.min.js",
           "stylesheet": null,
           "head": null,
           "attachment": null,
           "all_files": true
-        },
-        {
-          "name": "dt-core",
-          "version": "1.11.3",
-          "src": {
-            "href": "dt-core-1.11.3"
-          },
-          "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
-          "head": null,
-          "attachment": null,
-          "package": null,
-          "all_files": false
         },
         {
           "name": "crosstalk",
@@ -146,136 +365,37 @@
           "head": null,
           "attachment": null,
           "all_files": true
-        }
-      ]
-    },
-    "absence_unauth_reasons_table": {
-      "x": {
-        "filter": "none",
-        "vertical": false,
-        "container": "<table class=\"cell-border stripe\">\n  <thead>\n    <tr>\n      <th>Holiday<\/th>\n      <th>Late after registers closed<\/th>\n      <th>Other<\/th>\n      <th>No reason yet<\/th>\n    <\/tr>\n  <\/thead>\n<\/table>",
-        "options": {
-          "scrollX": true,
-          "ordering": false,
-          "searching": false,
-          "lengthChange": false,
-          "dom": "t",
-          "columnDefs": [
-            {
-              "targets": -1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 0,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 1,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "targets": 2,
-              "render": "function(data, type, row, meta) {\n    return type !== 'display' ? data : DTWidget.formatPercentage(data, 1, 3, \",\", \".\", null);\n  }"
-            },
-            {
-              "className": "dt-center",
-              "targets": [
-                0,
-                1,
-                2,
-                3
-              ]
-            }
-          ],
-          "order": [
-
-          ],
-          "autoWidth": false,
-          "orderClasses": false,
-          "ajax": {
-            "type": "POST",
-            "data": "function(d) {\nd.search.caseInsensitive = true;\nd.search.smart = true;\nd.escape = false;\nvar encodeAmp = function(x) { x.value = x.value.replace(/&/g, \"%26\"); }\nencodeAmp(d.search);\n$.each(d.columns, function(i, v) {encodeAmp(v.search);});\n}"
-          },
-          "serverSide": true,
-          "processing": true
-        },
-        "selection": {
-          "mode": "none",
-          "selected": null,
-          "target": "row",
-          "selectable": null
-        }
-      },
-      "evals": [
-        "options.columnDefs.0.render",
-        "options.columnDefs.1.render",
-        "options.columnDefs.2.render",
-        "options.columnDefs.3.render",
-        "options.ajax.data"
-      ],
-      "jsHooks": [
-
-      ],
-      "deps": [
-        {
-          "name": "jquery",
-          "version": "3.6.0",
-          "src": {
-            "href": "jquery-3.6.0"
-          },
-          "meta": null,
-          "script": "jquery-3.6.0.min.js",
-          "stylesheet": null,
-          "head": null,
-          "attachment": null,
-          "all_files": true
         },
         {
-          "name": "dt-core",
-          "version": "1.11.3",
+          "name": "plotly-htmlwidgets-css",
+          "version": "2.5.1",
           "src": {
-            "href": "dt-core-1.11.3"
+            "href": "plotly-htmlwidgets-css-2.5.1"
           },
           "meta": null,
-          "script": "js/jquery.dataTables.min.js",
-          "stylesheet": [
-            "css/jquery.dataTables.min.css",
-            "css/jquery.dataTables.extra.css"
-          ],
+          "script": null,
+          "stylesheet": "plotly-htmlwidgets.css",
           "head": null,
           "attachment": null,
-          "package": null,
           "all_files": false
         },
         {
-          "name": "crosstalk",
-          "version": "1.2.0",
+          "name": "plotly-main",
+          "version": "2.5.1",
           "src": {
-            "href": "crosstalk-1.2.0"
+            "href": "plotly-main-2.5.1"
           },
           "meta": null,
-          "script": "js/crosstalk.min.js",
-          "stylesheet": "css/crosstalk.min.css",
+          "script": "plotly-latest.min.js",
+          "stylesheet": null,
           "head": null,
           "attachment": null,
-          "all_files": true
+          "all_files": false
         }
-      ]
-    },
-    "headline_auth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>4%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
       ]
     },
     "headline_auth_rate_ytd": {
       "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>3.7%<\/h3>\n    <p>Year to date<\/p>\n  <\/div>\n<\/div>",
-      "deps": [
-
-      ]
-    },
-    "headline_unauth_rate_weekly": {
-      "html": "<div class=\"small-box bg-blue\">\n  <div class=\"inner\">\n    <h3>1.1%<\/h3>\n    <p>Most recent full week<\/p>\n  <\/div>\n<\/div>",
       "deps": [
 
       ]


### PR DESCRIPTION
Reasons time period toggle

## Pull request overview

Addition of time series toggle for reasons tab to mirror that on headlines.

## Pull request checklist

Please check if your PR fulfils the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`run_tests_locally()`)
- [x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

Reasons tab features blue boxes for most recent week and year to date however tables and chart just show info for most recent week.


## What is the new behaviour?

Reasons tab added time period switch to flip between most recent week and year to date. Corresponding year to date chart and reasons tables created to populate the tab.


## Anything else

N/A
