### PR TITLE
Remove la total filtering

### DIFF
--- a/R/prerun_utils.R
+++ b/R/prerun_utils.R
@@ -399,9 +399,9 @@ process_attendance_data <- function(attendance_data_raw, start_date, end_date, p
   # Add total onto Primary, Secondary, Special data
   attendance_data <- bind_rows(attendance_data, attendance_data_daily_totals, attendance_data_weekly_totals, attendance_data_ytd_totals)
 
-  attendance_data <- attendance_data %>%
-    dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
-    arrange(time_period, time_identifier)
+  # attendance_data <- attendance_data %>%
+  #   dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
+  #   arrange(time_period, time_identifier)
 
   # #Handle strike days
   # attendance_data <- attendance_data %>%
@@ -936,9 +936,9 @@ process_attendance_data_spring <- function(attendance_data_raw, spring_start, sp
   # Add total onto Primary, Secondary, Special data
   attendance_data_spring <- bind_rows(attendance_data_spring, attendance_data_spring_totals)
 
-  attendance_data_spring <- attendance_data_spring %>%
-    dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
-    arrange(time_period, time_identifier)
+  # attendance_data_spring <- attendance_data_spring %>%
+  #   dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
+  #   arrange(time_period, time_identifier)
 
   # Data suppression
   attendance_data_spring <- attendance_data_spring %>%
@@ -1209,9 +1209,9 @@ process_attendance_data_summer <- function(attendance_data_raw, summer_start, su
   # Add total onto Primary, Secondary, Special data
   attendance_data_summer <- bind_rows(attendance_data_summer, attendance_data_summer_totals)
 
-  attendance_data_summer <- attendance_data_summer %>%
-    dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
-    arrange(time_period, time_identifier)
+  # attendance_data_summer <- attendance_data_summer %>%
+  #   dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
+  #   arrange(time_period, time_identifier)
 
   # Data suppression
   attendance_data_summer <- attendance_data_summer %>%

--- a/R/prerun_utils.R
+++ b/R/prerun_utils.R
@@ -677,9 +677,9 @@ process_attendance_data_autumn <- function(attendance_data_raw, autumn_start, au
   # Add total onto Primary, Secondary, Special data
   attendance_data_autumn <- bind_rows(attendance_data_autumn, attendance_data_autumn_totals)
 
-  attendance_data_autumn <- attendance_data_autumn %>%
-    dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
-    arrange(time_period, time_identifier)
+  # attendance_data_autumn <- attendance_data_autumn %>%
+  #   dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")) %>%
+  #   arrange(time_period, time_identifier)
 
   # Data suppression
   attendance_data_autumn <- attendance_data_autumn %>%


### PR DESCRIPTION
## Pull request overview

LA totals are now required and therefore filtering has been removed (commented out)

## Pull request checklist

Please check if your PR fulfils the following:
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x ] Tests have been run locally and are passing (`run_tests_locally()`)
- [x ] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

(dplyr::filter(!(geographic_level == "Local authority" & school_type == "Total")))


## What is the new behaviour?

Section above has been commented out in 4 places (3 terms and YTD)

## Anything else


