### PR TITLE
2526 academic year dates - non-dashboard changes

### DIFF
--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -124,7 +124,7 @@ homepage_panel <- function() {
                   ),
                   a(
                     href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools",
-                    "Pupil attendance in schools - 2025/26 academic year"
+                    "Pupil attendance in schools - 2024/25 academic year"
                   ),
                   br(),
                   br(),
@@ -132,8 +132,8 @@ homepage_panel <- function() {
                     "For 2023/24 full academic year and termly pupil attendance data, including by characteristics, please see the historical publication at the link below:"
                   ),
                   a(
-                    href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools/2025-week-29",
-                    "Pupil attendance in schools - 2024/25 academic year"
+                    href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools/2024-week-29",
+                    "Pupil attendance in schools - 2023/24 academic year"
                   ),
                   br(),
                   br(),

--- a/R/dashboard_panels.R
+++ b/R/dashboard_panels.R
@@ -124,7 +124,7 @@ homepage_panel <- function() {
                   ),
                   a(
                     href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools",
-                    "Pupil attendance in schools - 2024/25 academic year"
+                    "Pupil attendance in schools - 2025/26 academic year"
                   ),
                   br(),
                   br(),
@@ -132,8 +132,8 @@ homepage_panel <- function() {
                     "For 2023/24 full academic year and termly pupil attendance data, including by characteristics, please see the historical publication at the link below:"
                   ),
                   a(
-                    href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools/2024-week-29",
-                    "Pupil attendance in schools - 2023/24 academic year"
+                    href = "https://explore-education-statistics.service.gov.uk/find-statistics/pupil-attendance-in-schools/2025-week-29",
+                    "Pupil attendance in schools - 2024/25 academic year"
                   ),
                   br(),
                   br(),

--- a/R/prerun_utils.R
+++ b/R/prerun_utils.R
@@ -15,13 +15,13 @@ run_data_update <- function() {
   school_freq_count <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.enrolments_schools_denominator")
   school_freq_count$total_enrolments <- as.numeric(school_freq_count$total_enrolments)
 
-  pa_fullyear_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.ytd_2425_pa_clean_delta")
+  pa_fullyear_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.ytd_2526_pa_clean_delta")
 
-  pa_autumn_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.aut_2425_pa_clean_delta")
-  pa_spring_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.spr_2425_pa_clean_delta")
-  pa_summer_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.sum_2324_pa_clean_delta")
+  pa_autumn_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.aut_2526_pa_clean_delta")
+  pa_spring_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.spr_2526_pa_clean_delta")
+  pa_summer_file <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.sum_2526_pa_clean_delta")
 
-  attendance_data_raw <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.ytd_2425_oa_clean_delta")
+  attendance_data_raw <- DBI::dbGetQuery(conn, "SELECT * FROM school_attendance_national_stats.ytd_2526_oa_clean_delta")
 
 
   attendance_data <- process_attendance_data(
@@ -537,7 +537,7 @@ process_attendance_data_autumn <- function(attendance_data_raw, autumn_start, au
       academic_year = min(academic_year),
       time_period = min(time_period),
       time_identifier = 37,
-      week_commencing = as.Date("2024-09-09"),
+      week_commencing = as.Date("2025-09-08"),
       num_schools = mean(num_schools),
       enrolments = mean(enrolments),
       present_sessions = sum(present_sessions),
@@ -1645,7 +1645,7 @@ create_ees_tables <- function(attendance_data) {
     arrange(time_period, school_type) %>%
     mutate(
       time_identifier = paste("Academic year"),
-      time_period = paste("202425")
+      time_period = paste("202526")
     ) %>%
     mutate_at(vars(
       enrolments,
@@ -1812,8 +1812,8 @@ create_ees_tables_autumn <- function(df_attendance_autumn) {
     arrange(time_period, school_type) %>%
     mutate(
       time_identifier = paste("Autumn term"),
-      time_period = paste("202425"),
-      academic_year = paste("202425")
+      time_period = paste("202526"),
+      academic_year = paste("202526")
     ) %>%
     mutate_at(vars(
       enrolments,
@@ -1966,8 +1966,8 @@ create_ees_tables_spring <- function(df_attendance_spring) {
     arrange(time_period, school_type) %>%
     mutate(
       time_identifier = paste("Spring term"),
-      time_period = paste("202425"),
-      academic_year = paste("202425")
+      time_period = paste("202526"),
+      academic_year = paste("202526")
     ) %>%
     mutate_at(vars(
       enrolments,
@@ -2115,8 +2115,8 @@ create_ees_tables_summer <- function(df_attendance_summer) {
     arrange(time_period, school_type) %>%
     mutate(
       time_identifier = paste("Summer term"),
-      time_period = paste("202425"),
-      academic_year = paste("202425")
+      time_period = paste("202526"),
+      academic_year = paste("202526")
     ) %>%
     mutate_at(vars(
       enrolments,

--- a/global.R
+++ b/global.R
@@ -92,8 +92,8 @@ team_email <- "school.statistics@education.gov.uk"
 # attendance_data_raw <- fread("data/Weekly_dummy_data.csv")
 
 #### SECTION 1 - date filters ####
-start_date <- as.Date("2024-09-09")
-end_date <- as.Date("2025-07-25")
+start_date <- as.Date("2025-09-01")
+end_date <- as.Date("2026-07-14")
 # funeral_date <- as.Date("2022-09-19")
 # strike_date_1 <- as.Date("2023-02-01")
 # strike_date_2 <- as.Date("2023-03-15")
@@ -108,12 +108,12 @@ end_date <- as.Date("2025-07-25")
 # regional_strike_3 <- as.Date("2023-03-02")
 
 
-autumn_start <- as.Date("2024-09-09")
-autumn_end <- as.Date("2024-12-21")
-spring_start <- as.Date("2025-01-06")
-spring_end <- as.Date("2025-04-12")
-summer_start <- as.Date("2025-04-14")
-summer_end <- as.Date("2025-07-25")
+autumn_start <- as.Date("2025-09-08")
+autumn_end <- as.Date("2025-12-21")
+#spring_start <- as.Date("2025-01-06")
+#spring_end <- as.Date("2025-04-12")
+#summer_start <- as.Date("2025-04-14")
+#summer_end <- as.Date("2025-07-25")
 
 # most_recent_week_dates <- paste0("Latest week - ", as.Date(end_date) - 4, " to ", as.Date(end_date))
 most_recent_week_dates <- paste0("Latest week - ", as.Date(end_date) - 11, " to ", as.Date(end_date) - 7) # Commented this in to edit dates in LA table current selections heading, will need reverting back to above line

--- a/global.R
+++ b/global.R
@@ -110,10 +110,10 @@ end_date <- as.Date("2026-07-14")
 
 autumn_start <- as.Date("2025-09-08")
 autumn_end <- as.Date("2025-12-21")
-#spring_start <- as.Date("2025-01-06")
-#spring_end <- as.Date("2025-04-12")
-#summer_start <- as.Date("2025-04-14")
-#summer_end <- as.Date("2025-07-25")
+# spring_start <- as.Date("2025-01-06")
+# spring_end <- as.Date("2025-04-12")
+# summer_start <- as.Date("2025-04-14")
+# summer_end <- as.Date("2025-07-25")
 
 # most_recent_week_dates <- paste0("Latest week - ", as.Date(end_date) - 4, " to ", as.Date(end_date))
 most_recent_week_dates <- paste0("Latest week - ", as.Date(end_date) - 11, " to ", as.Date(end_date) - 7) # Commented this in to edit dates in LA table current selections heading, will need reverting back to above line


### PR DESCRIPTION
## Pull request overview

Update of dates in global and prerun_utils for 2526

## Pull request checklist

Please check if your PR fulfils the following:
- [x ] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x ] Tests have been run locally and are passing (`run_tests_locally()`)
- [ x] Code is styled according to tidyverse styling (checked locally with `tidy_code()`)


## What is the current behaviour?

Dates aligned to 2425 academic year


## What is the new behaviour?

Dates updated to 2526 academic year

## Anything else

Updated inline with internal dashboard
